### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.gitignore
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.6-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+            build-essential \
+            libssl-dev \
+            libffi-dev \
+            python-dev \
+        && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /Anubis/
+COPY . /Anubis/
+
+RUN pip3 install .
+
+ENTRYPOINT ["anubis"]


### PR DESCRIPTION
This should allow for automated builds on Docker Hub.
Furthermore, it will allow users to run `anubis` without
a local installation of Python (or its dependencies).

---

There's some extra configuration steps needed https://hub.docker.com/. 

Let me know what you think.
